### PR TITLE
Google C++スタイルガイド準拠リファクタリングとテスト追加

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,25 +19,37 @@ find_package(rabcl REQUIRED)
 
 include_directories(include)
 
-add_executable(gamepad_node
+# Libraries (logic without main)
+add_library(gamepad_lib STATIC
   src/gamepad_node.cpp
 )
-ament_target_dependencies(gamepad_node
+ament_target_dependencies(gamepad_lib
   rclcpp
   sensor_msgs
   attracts_msgs
   rabcl
 )
 
-add_executable(game_client_node
+add_library(game_client_lib STATIC
   src/game_client_node.cpp
 )
-ament_target_dependencies(game_client_node
+ament_target_dependencies(game_client_lib
   rclcpp
   sensor_msgs
   attracts_msgs
   rabcl
 )
+
+# Executables
+add_executable(gamepad_node
+  src/gamepad_main.cpp
+)
+target_link_libraries(gamepad_node gamepad_lib)
+
+add_executable(game_client_node
+  src/game_client_main.cpp
+)
+target_link_libraries(game_client_node game_client_lib)
 
 install(TARGETS
   gamepad_node
@@ -49,5 +61,20 @@ install(DIRECTORY
   launch
   DESTINATION share/${PROJECT_NAME}
 )
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  set(ament_cmake_copyright_FOUND TRUE)
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_gtest REQUIRED)
+
+  ament_add_gtest(test_game_client test/test_game_client.cpp)
+  target_link_libraries(test_game_client game_client_lib)
+
+  ament_add_gtest(test_gamepad test/test_gamepad.cpp)
+  target_link_libraries(test_gamepad gamepad_lib)
+endif()
 
 ament_package()

--- a/include/attracts_interface/game_client_node.hpp
+++ b/include/attracts_interface/game_client_node.hpp
@@ -1,38 +1,40 @@
-#ifndef GAME_CLIENT_NODE_HPP
-#define GAME_CLIENT_NODE_HPP
+#ifndef ATTRACTS_INTERFACE__GAME_CLIENT_NODE_HPP_
+#define ATTRACTS_INTERFACE__GAME_CLIENT_NODE_HPP_
+
+#include <array>
+#include <string>
 
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/joint_state.hpp>
-#include <attracts_msgs/msg/game_data_input.hpp>
-#include <attracts_msgs/msg/attracts_command.hpp>
+
+#include "attracts_msgs/msg/attracts_command.hpp"
+#include "attracts_msgs/msg/game_data_input.hpp"
 
 class GameClient : public rclcpp::Node
 {
 public:
-    GameClient();
+  explicit GameClient(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+
+  void GameDataInputCB(const attracts_msgs::msg::GameDataInput::SharedPtr msg);
+  void TimerCB();
+  void UpdateCmdVel(attracts_msgs::msg::AttractsCommand & cmd);
+  void UpdatePositions(const attracts_msgs::msg::AttractsCommand & cmd);
 
 private:
-    void GameDataInputCB(const attracts_msgs::msg::GameDataInput::SharedPtr msg);
-    void TimerCB();
-    void UpdateCmdVel(attracts_msgs::msg::AttractsCommand& cmd);
-    void UpdatePositions(const attracts_msgs::msg::AttractsCommand& cmd);
+  rclcpp::Publisher<attracts_msgs::msg::AttractsCommand>::SharedPtr cmd_pub_;
+  rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr joint_state_pub_;
+  rclcpp::Subscription<attracts_msgs::msg::GameDataInput>::SharedPtr game_data_input_sub_;
+  rclcpp::TimerBase::SharedPtr timer_;
 
-private:
-    rclcpp::Publisher<attracts_msgs::msg::AttractsCommand>::SharedPtr cmd_pub_;
-    rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr joint_state_pub_;
-    rclcpp::Subscription<attracts_msgs::msg::GameDataInput>::SharedPtr game_data_input_sub_;
-    rclcpp::TimerBase::SharedPtr timer_;
+  double wheel_d_ = 0.06;  // m
+  double body_d_ = 0.28;   // m
+  double max_omni_vel_;     // m/s
+  double max_omni_rot_vel_;  // rad/s
+  double max_yaw_rot_vel_;   // rad/s
+  double max_pitch_rot_vel_;  // rad/s
 
-private:
-    double wheel_d_ = 0.06; // m
-    double body_d_ = 0.28; // m
-    double max_omni_vel_; // m/s
-    double max_omni_rot_vel_; // rad/s
-    double max_yaw_rot_vel_; // rad/s
-    double max_pitch_rot_vel_; // rad/s
-
-    attracts_msgs::msg::GameDataInput game_data_input_msg_;
-    std::array<double, 6> positions_;
+  attracts_msgs::msg::GameDataInput game_data_input_msg_;
+  std::array<double, 6> positions_;
 };
 
-#endif
+#endif  // ATTRACTS_INTERFACE__GAME_CLIENT_NODE_HPP_

--- a/include/attracts_interface/gamepad_node.hpp
+++ b/include/attracts_interface/gamepad_node.hpp
@@ -1,38 +1,40 @@
-#ifndef GAMEPAD_NODE_HPP
-#define GAMEPAD_NODE_HPP
+#ifndef ATTRACTS_INTERFACE__GAMEPAD_NODE_HPP_
+#define ATTRACTS_INTERFACE__GAMEPAD_NODE_HPP_
+
+#include <array>
+#include <string>
 
 #include <rclcpp/rclcpp.hpp>
-#include <sensor_msgs/msg/joy.hpp>
 #include <sensor_msgs/msg/joint_state.hpp>
-#include <attracts_msgs/msg/attracts_command.hpp>
+#include <sensor_msgs/msg/joy.hpp>
+
+#include "attracts_msgs/msg/attracts_command.hpp"
 
 class Gamepad : public rclcpp::Node
 {
 public:
-    Gamepad();
+  explicit Gamepad(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+
+  void JoyCB(const sensor_msgs::msg::Joy::SharedPtr msg);
+  void TimerCB();
+  void UpdateCmdVel(attracts_msgs::msg::AttractsCommand & cmd);
+  void UpdatePositions(const attracts_msgs::msg::AttractsCommand & cmd);
 
 private:
-    void JoyCB(const sensor_msgs::msg::Joy::SharedPtr msg);
-    void TimerCB();
-    void UpdateCmdVel(attracts_msgs::msg::AttractsCommand& cmd);
-    void UpdatePositions(const attracts_msgs::msg::AttractsCommand& cmd);
+  rclcpp::Publisher<attracts_msgs::msg::AttractsCommand>::SharedPtr cmd_pub_;
+  rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr joint_state_pub_;
+  rclcpp::Subscription<sensor_msgs::msg::Joy>::SharedPtr joy_sub_;
+  rclcpp::TimerBase::SharedPtr timer_;
 
-private:
-    rclcpp::Publisher<attracts_msgs::msg::AttractsCommand>::SharedPtr cmd_pub_;
-    rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr joint_state_pub_;
-    rclcpp::Subscription<sensor_msgs::msg::Joy>::SharedPtr joy_sub_;
-    rclcpp::TimerBase::SharedPtr timer_;
+  double wheel_d_ = 0.06;  // m
+  double body_d_ = 0.28;   // m
+  double max_omni_vel_;     // m/s
+  double max_omni_rot_vel_;  // rad/s
+  double max_yaw_rot_vel_;   // rad/s
+  double max_pitch_rot_vel_;  // rad/s
 
-private:
-    double wheel_d_ = 0.06; // m
-    double body_d_ = 0.28; // m
-    double max_omni_vel_; // m/s
-    double max_omni_rot_vel_; // rad/s
-    double max_yaw_rot_vel_; // rad/s
-    double max_pitch_rot_vel_; // rad/s
-
-    sensor_msgs::msg::Joy joy_msg_;
-    std::array<double, 6> positions_;
+  sensor_msgs::msg::Joy joy_msg_;
+  std::array<double, 6> positions_;
 };
 
-#endif
+#endif  // ATTRACTS_INTERFACE__GAMEPAD_NODE_HPP_

--- a/launch/game_client.launch.py
+++ b/launch/game_client.launch.py
@@ -1,15 +1,16 @@
 from launch import LaunchDescription
-from launch_ros.actions import Node
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
 
 def generate_launch_description():
     ld = LaunchDescription()
 
-    ld.add_action(DeclareLaunchArgument('max_omni_vel', default_value='0.4')) # m/s
-    ld.add_action(DeclareLaunchArgument('max_omni_rot_vel', default_value='1.0')) # rad/s
-    ld.add_action(DeclareLaunchArgument('max_yaw_rot_vel', default_value='2.0')) # rad/s
-    ld.add_action(DeclareLaunchArgument('max_pitch_rot_vel', default_value='2.0')) # rad/s
+    ld.add_action(DeclareLaunchArgument('max_omni_vel', default_value='0.4'))
+    ld.add_action(DeclareLaunchArgument('max_omni_rot_vel', default_value='1.0'))
+    ld.add_action(DeclareLaunchArgument('max_yaw_rot_vel', default_value='2.0'))
+    ld.add_action(DeclareLaunchArgument('max_pitch_rot_vel', default_value='2.0'))
 
     game_client_node = Node(
         package='attracts_interface',

--- a/launch/gamepad.launch.py
+++ b/launch/gamepad.launch.py
@@ -1,15 +1,16 @@
 from launch import LaunchDescription
-from launch_ros.actions import Node
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
 
 def generate_launch_description():
     ld = LaunchDescription()
 
-    ld.add_action(DeclareLaunchArgument('max_omni_vel', default_value='0.4')) # m/s
-    ld.add_action(DeclareLaunchArgument('max_omni_rot_vel', default_value='1.0')) # rad/s
-    ld.add_action(DeclareLaunchArgument('max_yaw_rot_vel', default_value='2.0')) # rad/s
-    ld.add_action(DeclareLaunchArgument('max_pitch_rot_vel', default_value='2.0')) # rad/s
+    ld.add_action(DeclareLaunchArgument('max_omni_vel', default_value='0.4'))
+    ld.add_action(DeclareLaunchArgument('max_omni_rot_vel', default_value='1.0'))
+    ld.add_action(DeclareLaunchArgument('max_yaw_rot_vel', default_value='2.0'))
+    ld.add_action(DeclareLaunchArgument('max_pitch_rot_vel', default_value='2.0'))
 
     joy_node = Node(
         package='joy_linux',

--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,7 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/game_client_main.cpp
+++ b/src/game_client_main.cpp
@@ -1,0 +1,11 @@
+#include <rclcpp/rclcpp.hpp>
+
+#include "attracts_interface/game_client_node.hpp"
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<GameClient>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/src/game_client_node.cpp
+++ b/src/game_client_node.cpp
@@ -1,136 +1,131 @@
 #include "attracts_interface/game_client_node.hpp"
 
+#include <cmath>
+#include <functional>
+
 #include <rabcl/controller/omni_drive.hpp>
 
-GameClient::GameClient() : Node("game_client_node")
+GameClient::GameClient(const rclcpp::NodeOptions & options)
+: Node("game_client_node", options), positions_{}
 {
-    max_omni_vel_ = this->declare_parameter("max_omni_vel", 0.0);
-    max_omni_rot_vel_ = this->declare_parameter("max_omni_rot_vel", 0.0);
-    max_yaw_rot_vel_ = this->declare_parameter("max_yaw_rot_vel", 0.0);
-    max_pitch_rot_vel_ = this->declare_parameter("max_pitch_rot_vel", 0.0);
+  max_omni_vel_ = this->declare_parameter("max_omni_vel", 0.0);
+  max_omni_rot_vel_ = this->declare_parameter("max_omni_rot_vel", 0.0);
+  max_yaw_rot_vel_ = this->declare_parameter("max_yaw_rot_vel", 0.0);
+  max_pitch_rot_vel_ = this->declare_parameter("max_pitch_rot_vel", 0.0);
 
-    cmd_pub_ = this->create_publisher<attracts_msgs::msg::AttractsCommand>("cmd", 10);
-    joint_state_pub_ = this->create_publisher<sensor_msgs::msg::JointState>("/joint_states", 10);
-    game_data_input_sub_ = this->create_subscription<attracts_msgs::msg::GameDataInput>(
-        "/game_data_input", 10, std::bind(&GameClient::GameDataInputCB, this, std::placeholders::_1));
-    using namespace std::chrono_literals;
-    timer_ = this->create_wall_timer(25ms, std::bind(&GameClient::TimerCB, this));
+  cmd_pub_ = this->create_publisher<attracts_msgs::msg::AttractsCommand>("cmd", 10);
+  joint_state_pub_ =
+    this->create_publisher<sensor_msgs::msg::JointState>("/joint_states", 10);
+  game_data_input_sub_ = this->create_subscription<attracts_msgs::msg::GameDataInput>(
+    "/game_data_input", 10,
+    std::bind(&GameClient::GameDataInputCB, this, std::placeholders::_1));
+  using namespace std::chrono_literals;
+  timer_ = this->create_wall_timer(25ms, std::bind(&GameClient::TimerCB, this));
 }
 
 void GameClient::GameDataInputCB(const attracts_msgs::msg::GameDataInput::SharedPtr msg)
 {
-    game_data_input_msg_ = *msg;
+  game_data_input_msg_ = *msg;
 }
 
 void GameClient::TimerCB()
 {
-    attracts_msgs::msg::AttractsCommand cmd; // rad/s
-    UpdateCmdVel(cmd);
-    UpdatePositions(cmd);
+  attracts_msgs::msg::AttractsCommand cmd;  // rad/s
+  UpdateCmdVel(cmd);
+  UpdatePositions(cmd);
 }
 
-void GameClient::UpdateCmdVel(attracts_msgs::msg::AttractsCommand& cmd)
+void GameClient::UpdateCmdVel(attracts_msgs::msg::AttractsCommand & cmd)
 {
-    // --- 足回り
-    // 並進
-    if (game_data_input_msg_.key_w) {
-        cmd.chassis_vel.x = max_omni_vel_;
-    }
-    if (game_data_input_msg_.key_s) {
-        cmd.chassis_vel.x = -max_omni_vel_;
-    }
-    if (game_data_input_msg_.key_a) {
-        cmd.chassis_vel.y = max_omni_vel_;
-    }
-    if (game_data_input_msg_.key_d) {
-        cmd.chassis_vel.y = -max_omni_vel_;
-    }
-    // 回転
-    if (game_data_input_msg_.key_z) {
-        cmd.chassis_vel.z = max_omni_rot_vel_;
-    } else if (game_data_input_msg_.key_c) {
-        cmd.chassis_vel.z = -1.0 * max_omni_rot_vel_;
-    }
+  // --- 足回り
+  // 並進
+  if (game_data_input_msg_.key_w) {
+    cmd.chassis_vel.x = max_omni_vel_;
+  }
+  if (game_data_input_msg_.key_s) {
+    cmd.chassis_vel.x = -max_omni_vel_;
+  }
+  if (game_data_input_msg_.key_a) {
+    cmd.chassis_vel.y = max_omni_vel_;
+  }
+  if (game_data_input_msg_.key_d) {
+    cmd.chassis_vel.y = -max_omni_vel_;
+  }
+  // 回転
+  if (game_data_input_msg_.key_z) {
+    cmd.chassis_vel.z = max_omni_rot_vel_;
+  } else if (game_data_input_msg_.key_c) {
+    cmd.chassis_vel.z = -1.0 * max_omni_rot_vel_;
+  }
 
-    // --- 砲塔
-    // yaw
-    cmd.yaw_pos =
-        positions_.at(4) + (double)game_data_input_msg_.mouse_delta_x / 100.0;
-    cmd.yaw_pos = std::fmod(cmd.yaw_pos, 2.0 * M_PI);
-    if (cmd.yaw_pos < 0) {
-        cmd.yaw_pos += 2.0 * M_PI;
-    }
-    // pitch
-    cmd.pitch_pos =
-        positions_.at(5) + (double)game_data_input_msg_.mouse_delta_y / 100.0;
-    if (cmd.pitch_pos < -M_PI / 12)
-    {
-        cmd.pitch_pos = -M_PI / 12;
-    }
-    if (cmd.pitch_pos > M_PI / 6)
-    {
-        cmd.pitch_pos = M_PI / 6;
-    }
-    // 前回指令値を保存
-    positions_.at(4) = cmd.yaw_pos;
-    positions_.at(5) = cmd.pitch_pos;
+  // --- 砲塔
+  // yaw
+  cmd.yaw_pos =
+    positions_.at(4) + static_cast<double>(game_data_input_msg_.mouse_delta_x) / 100.0;
+  cmd.yaw_pos = std::fmod(cmd.yaw_pos, 2.0 * M_PI);
+  if (cmd.yaw_pos < 0) {
+    cmd.yaw_pos += 2.0 * M_PI;
+  }
+  // pitch
+  cmd.pitch_pos =
+    positions_.at(5) + static_cast<double>(game_data_input_msg_.mouse_delta_y) / 100.0;
+  if (cmd.pitch_pos < -M_PI / 12) {
+    cmd.pitch_pos = -M_PI / 12;
+  }
+  if (cmd.pitch_pos > M_PI / 6) {
+    cmd.pitch_pos = M_PI / 6;
+  }
+  // 前回指令値を保存
+  positions_.at(4) = cmd.yaw_pos;
+  positions_.at(5) = cmd.pitch_pos;
 
-    // --- 動作モード
-    if (game_data_input_msg_.mouse_right_button) {
-        cmd.fire_mode = 1;
-    }
-    if (game_data_input_msg_.mouse_left_button) {
-        cmd.load_mode = 1;
-    }
-    if (game_data_input_msg_.key_r) {
-        cmd.load_mode = 2;
-    }
-    cmd.speed_mode = 0;
-    if (game_data_input_msg_.key_shift) {
-        cmd.chassis_mode = 1;
-    }
+  // --- 動作モード
+  if (game_data_input_msg_.mouse_right_button) {
+    cmd.fire_mode = 1;
+  }
+  if (game_data_input_msg_.mouse_left_button) {
+    cmd.load_mode = 1;
+  }
+  if (game_data_input_msg_.key_r) {
+    cmd.load_mode = 2;
+  }
+  cmd.speed_mode = 0;
+  if (game_data_input_msg_.key_shift) {
+    cmd.chassis_mode = 1;
+  }
 
-    cmd_pub_->publish(cmd);
+  cmd_pub_->publish(cmd);
 }
 
-void GameClient::UpdatePositions(const attracts_msgs::msg::AttractsCommand& cmd)
+void GameClient::UpdatePositions(const attracts_msgs::msg::AttractsCommand & cmd)
 {
-    rabcl::OmniDrive omni_drive(wheel_d_, body_d_);
-    std::array<double, 6> joint_vel;
-    omni_drive.CalcVel(
-        cmd.chassis_vel.x, cmd.chassis_vel.y, cmd.chassis_vel.z,
-        joint_vel.at(0), joint_vel.at(1), joint_vel.at(2), joint_vel.at(3),
-        positions_.at(4));
-    positions_.at(4) = cmd.yaw_pos;
-    positions_.at(5) = cmd.pitch_pos;
+  rabcl::OmniDrive omni_drive(wheel_d_, body_d_);
+  std::array<double, 6> joint_vel;
+  omni_drive.CalcVel(
+    cmd.chassis_vel.x, cmd.chassis_vel.y, cmd.chassis_vel.z,
+    joint_vel.at(0), joint_vel.at(1), joint_vel.at(2), joint_vel.at(3),
+    positions_.at(4));
+  positions_.at(4) = cmd.yaw_pos;
+  positions_.at(5) = cmd.pitch_pos;
 
-    double game_client_freq = 20.0; // Hz
-    for (int i = 0; i < 6; i++)
-    {
-        positions_.at(i) += joint_vel.at(i) / game_client_freq;
-    }
+  double game_client_freq = 20.0;  // Hz
+  for (int i = 0; i < 6; i++) {
+    positions_.at(i) += joint_vel.at(i) / game_client_freq;
+  }
 
-    sensor_msgs::msg::JointState joint_state;
-    joint_state.header.stamp = get_clock()->now();
-    joint_state.name.emplace_back("right_front_wheel_joint");
-    joint_state.name.emplace_back("left_front_wheel_joint");
-    joint_state.name.emplace_back("right_back_wheel_joint");
-    joint_state.name.emplace_back("left_back_wheel_joint");
-    joint_state.name.emplace_back("yaw_joint");
-    joint_state.name.emplace_back("pitch_joint");
-    joint_state.position.emplace_back(positions_.at(0));
-    joint_state.position.emplace_back(positions_.at(1));
-    joint_state.position.emplace_back(positions_.at(2));
-    joint_state.position.emplace_back(positions_.at(3));
-    joint_state.position.emplace_back(positions_.at(4));
-    joint_state.position.emplace_back(positions_.at(5));
-    joint_state_pub_->publish(joint_state);
-}
-
-int main(int argc, char **argv)
-{
-    rclcpp::init(argc, argv);
-    rclcpp::spin(std::make_shared<GameClient>());
-    rclcpp::shutdown();
-    return 0;
+  sensor_msgs::msg::JointState joint_state;
+  joint_state.header.stamp = get_clock()->now();
+  joint_state.name.emplace_back("right_front_wheel_joint");
+  joint_state.name.emplace_back("left_front_wheel_joint");
+  joint_state.name.emplace_back("right_back_wheel_joint");
+  joint_state.name.emplace_back("left_back_wheel_joint");
+  joint_state.name.emplace_back("yaw_joint");
+  joint_state.name.emplace_back("pitch_joint");
+  joint_state.position.emplace_back(positions_.at(0));
+  joint_state.position.emplace_back(positions_.at(1));
+  joint_state.position.emplace_back(positions_.at(2));
+  joint_state.position.emplace_back(positions_.at(3));
+  joint_state.position.emplace_back(positions_.at(4));
+  joint_state.position.emplace_back(positions_.at(5));
+  joint_state_pub_->publish(joint_state);
 }

--- a/src/gamepad_main.cpp
+++ b/src/gamepad_main.cpp
@@ -1,0 +1,11 @@
+#include <rclcpp/rclcpp.hpp>
+
+#include "attracts_interface/gamepad_node.hpp"
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<Gamepad>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/src/gamepad_node.cpp
+++ b/src/gamepad_node.cpp
@@ -1,131 +1,124 @@
 #include "attracts_interface/gamepad_node.hpp"
 
+#include <cmath>
+#include <functional>
+
 #include <rabcl/controller/omni_drive.hpp>
 
-Gamepad::Gamepad() : Node("gamepad_node")
+Gamepad::Gamepad(const rclcpp::NodeOptions & options)
+: Node("gamepad_node", options), positions_{}
 {
-    max_omni_vel_ = this->declare_parameter("max_omni_vel", 0.0);
-    max_omni_rot_vel_ = this->declare_parameter("max_omni_rot_vel", 0.0);
-    max_yaw_rot_vel_ = this->declare_parameter("max_yaw_rot_vel", 0.0);
-    max_pitch_rot_vel_ = this->declare_parameter("max_pitch_rot_vel", 0.0);
+  max_omni_vel_ = this->declare_parameter("max_omni_vel", 0.0);
+  max_omni_rot_vel_ = this->declare_parameter("max_omni_rot_vel", 0.0);
+  max_yaw_rot_vel_ = this->declare_parameter("max_yaw_rot_vel", 0.0);
+  max_pitch_rot_vel_ = this->declare_parameter("max_pitch_rot_vel", 0.0);
 
-    cmd_pub_ = this->create_publisher<attracts_msgs::msg::AttractsCommand>("cmd", 10);
-    joint_state_pub_ = this->create_publisher<sensor_msgs::msg::JointState>("/joint_states", 10);
-    joy_sub_ = this->create_subscription<sensor_msgs::msg::Joy>("joy", 10, std::bind(&Gamepad::JoyCB, this, std::placeholders::_1));
-    using namespace std::chrono_literals;
-    timer_ = this->create_wall_timer(25ms, std::bind(&Gamepad::TimerCB, this));
+  cmd_pub_ = this->create_publisher<attracts_msgs::msg::AttractsCommand>("cmd", 10);
+  joint_state_pub_ =
+    this->create_publisher<sensor_msgs::msg::JointState>("/joint_states", 10);
+  joy_sub_ = this->create_subscription<sensor_msgs::msg::Joy>(
+    "joy", 10,
+    std::bind(&Gamepad::JoyCB, this, std::placeholders::_1));
+  using namespace std::chrono_literals;
+  timer_ = this->create_wall_timer(25ms, std::bind(&Gamepad::TimerCB, this));
 }
 
 void Gamepad::JoyCB(const sensor_msgs::msg::Joy::SharedPtr msg)
 {
-    joy_msg_ = *msg;
+  joy_msg_ = *msg;
 }
 
 void Gamepad::TimerCB()
 {
-    attracts_msgs::msg::AttractsCommand cmd;
-    if (joy_msg_.axes.size() > 0 && joy_msg_.buttons.size() > 0)
-    {
-        UpdateCmdVel(cmd);
-        UpdatePositions(cmd);
-    }
+  attracts_msgs::msg::AttractsCommand cmd;
+  if (joy_msg_.axes.size() > 0 && joy_msg_.buttons.size() > 0) {
+    UpdateCmdVel(cmd);
+    UpdatePositions(cmd);
+  }
 }
 
-void Gamepad::UpdateCmdVel(attracts_msgs::msg::AttractsCommand& cmd)
+void Gamepad::UpdateCmdVel(attracts_msgs::msg::AttractsCommand & cmd)
 {
-    // --- 足回り
-    // 並進
-    if (joy_msg_.axes.at(7) == 1.0) {
-        cmd.chassis_vel.x = max_omni_vel_;
-    }
-    if (joy_msg_.axes.at(7) == -1.0) {
-        cmd.chassis_vel.x = -max_omni_vel_;
-    }
-    if (joy_msg_.axes.at(6) == 1.0) {
-        cmd.chassis_vel.y = max_omni_vel_;
-    }
-    if (joy_msg_.axes.at(6) == -1.0) {
-        cmd.chassis_vel.y = -max_omni_vel_;
-    }
-    // 回転
-    if (joy_msg_.buttons.at(6) == 1) {
-        cmd.chassis_vel.z = max_omni_rot_vel_;
-    }
-    else if (joy_msg_.buttons.at(7) == 1) {
-        cmd.chassis_vel.z = -1.0 * max_omni_rot_vel_;
-    }
+  // --- 足回り
+  // 並進
+  if (joy_msg_.axes.at(7) == 1.0) {
+    cmd.chassis_vel.x = max_omni_vel_;
+  }
+  if (joy_msg_.axes.at(7) == -1.0) {
+    cmd.chassis_vel.x = -max_omni_vel_;
+  }
+  if (joy_msg_.axes.at(6) == 1.0) {
+    cmd.chassis_vel.y = max_omni_vel_;
+  }
+  if (joy_msg_.axes.at(6) == -1.0) {
+    cmd.chassis_vel.y = -max_omni_vel_;
+  }
+  // 回転
+  if (joy_msg_.buttons.at(6) == 1) {
+    cmd.chassis_vel.z = max_omni_rot_vel_;
+  } else if (joy_msg_.buttons.at(7) == 1) {
+    cmd.chassis_vel.z = -1.0 * max_omni_rot_vel_;
+  }
 
-    // --- 砲塔
-    // yaw
-    cmd.yaw_pos = positions_.at(4) + joy_msg_.axes.at(3) / 10.0;
-    cmd.yaw_pos = std::fmod(cmd.yaw_pos, 2.0 * M_PI);
-    if (cmd.yaw_pos < 0) {
-        cmd.yaw_pos += 2.0 * M_PI;
-    }
-    // pitch
-    cmd.pitch_pos = positions_.at(5) + joy_msg_.axes.at(4) / 10.0;
-    if (cmd.pitch_pos < -M_PI / 12)
-    {
-        cmd.pitch_pos = -M_PI / 12;
-    }
-    if (cmd.pitch_pos > M_PI / 6)
-    {
-        cmd.pitch_pos = M_PI / 6;
-    }
-    // 前回指令値を保存
-    positions_.at(4) = cmd.yaw_pos;
-    positions_.at(5) = cmd.pitch_pos;
+  // --- 砲塔
+  // yaw
+  cmd.yaw_pos = positions_.at(4) + joy_msg_.axes.at(3) / 10.0;
+  cmd.yaw_pos = std::fmod(cmd.yaw_pos, 2.0 * M_PI);
+  if (cmd.yaw_pos < 0) {
+    cmd.yaw_pos += 2.0 * M_PI;
+  }
+  // pitch
+  cmd.pitch_pos = positions_.at(5) + joy_msg_.axes.at(4) / 10.0;
+  if (cmd.pitch_pos < -M_PI / 12) {
+    cmd.pitch_pos = -M_PI / 12;
+  }
+  if (cmd.pitch_pos > M_PI / 6) {
+    cmd.pitch_pos = M_PI / 6;
+  }
+  // 前回指令値を保存
+  positions_.at(4) = cmd.yaw_pos;
+  positions_.at(5) = cmd.pitch_pos;
 
-    // --- 動作モード
-    cmd.fire_mode = joy_msg_.buttons.at(5);
-    cmd.load_mode = joy_msg_.buttons.at(4);
-    if (joy_msg_.buttons.at(0) == 1)
-    {
-        cmd.load_mode = 2;
-    }
-    cmd.speed_mode = 0;
-    cmd.chassis_mode = joy_msg_.buttons.at(1);
-    cmd_pub_->publish(cmd);
+  // --- 動作モード
+  cmd.fire_mode = joy_msg_.buttons.at(5);
+  cmd.load_mode = joy_msg_.buttons.at(4);
+  if (joy_msg_.buttons.at(0) == 1) {
+    cmd.load_mode = 2;
+  }
+  cmd.speed_mode = 0;
+  cmd.chassis_mode = joy_msg_.buttons.at(1);
+  cmd_pub_->publish(cmd);
 }
 
-void Gamepad::UpdatePositions(const attracts_msgs::msg::AttractsCommand& cmd)
+void Gamepad::UpdatePositions(const attracts_msgs::msg::AttractsCommand & cmd)
 {
-    rabcl::OmniDrive omni_drive(wheel_d_, body_d_);
-    std::array<double, 6> joint_vel;
-    omni_drive.CalcVel(
-        cmd.chassis_vel.x, cmd.chassis_vel.y, cmd.chassis_vel.z,
-        joint_vel.at(0), joint_vel.at(1), joint_vel.at(2), joint_vel.at(3),
-        positions_.at(4));
-    positions_.at(4) = cmd.yaw_pos;
-    positions_.at(5) = cmd.pitch_pos;
+  rabcl::OmniDrive omni_drive(wheel_d_, body_d_);
+  std::array<double, 6> joint_vel;
+  omni_drive.CalcVel(
+    cmd.chassis_vel.x, cmd.chassis_vel.y, cmd.chassis_vel.z,
+    joint_vel.at(0), joint_vel.at(1), joint_vel.at(2), joint_vel.at(3),
+    positions_.at(4));
+  positions_.at(4) = cmd.yaw_pos;
+  positions_.at(5) = cmd.pitch_pos;
 
-    double joy_freq = 40.0; // Hz
-    for (int i = 0; i < 6; i++)
-    {
-        positions_.at(i) += joint_vel.at(i) / joy_freq;
-    }
+  double joy_freq = 40.0;  // Hz
+  for (int i = 0; i < 6; i++) {
+    positions_.at(i) += joint_vel.at(i) / joy_freq;
+  }
 
-    sensor_msgs::msg::JointState joint_state;
-    joint_state.header.stamp = get_clock()->now();
-    joint_state.name.emplace_back("right_front_wheel_joint");
-    joint_state.name.emplace_back("left_front_wheel_joint");
-    joint_state.name.emplace_back("right_back_wheel_joint");
-    joint_state.name.emplace_back("left_back_wheel_joint");
-    joint_state.name.emplace_back("yaw_joint");
-    joint_state.name.emplace_back("pitch_joint");
-    joint_state.position.emplace_back(positions_.at(0));
-    joint_state.position.emplace_back(positions_.at(1));
-    joint_state.position.emplace_back(positions_.at(2));
-    joint_state.position.emplace_back(positions_.at(3));
-    joint_state.position.emplace_back(positions_.at(4));
-    joint_state.position.emplace_back(positions_.at(5));
-    joint_state_pub_->publish(joint_state);
-}
-
-int main(int argc, char **argv)
-{
-    rclcpp::init(argc, argv);
-    rclcpp::spin(std::make_shared<Gamepad>());
-    rclcpp::shutdown();
-    return 0;
+  sensor_msgs::msg::JointState joint_state;
+  joint_state.header.stamp = get_clock()->now();
+  joint_state.name.emplace_back("right_front_wheel_joint");
+  joint_state.name.emplace_back("left_front_wheel_joint");
+  joint_state.name.emplace_back("right_back_wheel_joint");
+  joint_state.name.emplace_back("left_back_wheel_joint");
+  joint_state.name.emplace_back("yaw_joint");
+  joint_state.name.emplace_back("pitch_joint");
+  joint_state.position.emplace_back(positions_.at(0));
+  joint_state.position.emplace_back(positions_.at(1));
+  joint_state.position.emplace_back(positions_.at(2));
+  joint_state.position.emplace_back(positions_.at(3));
+  joint_state.position.emplace_back(positions_.at(4));
+  joint_state.position.emplace_back(positions_.at(5));
+  joint_state_pub_->publish(joint_state);
 }

--- a/test/test_game_client.cpp
+++ b/test/test_game_client.cpp
@@ -1,0 +1,208 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include "attracts_interface/game_client_node.hpp"
+
+class GameClientTest : public ::testing::Test
+{
+protected:
+  static void SetUpTestSuite()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestSuite()
+  {
+    rclcpp::shutdown();
+  }
+
+  void SetUp() override
+  {
+    auto options = rclcpp::NodeOptions().parameter_overrides({
+      rclcpp::Parameter("max_omni_vel", 1.0),
+      rclcpp::Parameter("max_omni_rot_vel", 2.0),
+      rclcpp::Parameter("max_yaw_rot_vel", 3.0),
+      rclcpp::Parameter("max_pitch_rot_vel", 3.0),
+      });
+    node_ = std::make_shared<GameClient>(options);
+  }
+
+  void TearDown() override
+  {
+    node_.reset();
+  }
+
+  std::shared_ptr<GameClient> node_;
+};
+
+static attracts_msgs::msg::GameDataInput MakeInput()
+{
+  return attracts_msgs::msg::GameDataInput();
+}
+
+TEST_F(GameClientTest, KeyWSetsChassisFwd)
+{
+  auto input = MakeInput();
+  input.key_w = true;
+  node_->GameDataInputCB(std::make_shared<attracts_msgs::msg::GameDataInput>(input));
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_DOUBLE_EQ(1.0, cmd.chassis_vel.x);
+}
+
+TEST_F(GameClientTest, KeySSetsChassisBwd)
+{
+  auto input = MakeInput();
+  input.key_s = true;
+  node_->GameDataInputCB(std::make_shared<attracts_msgs::msg::GameDataInput>(input));
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_DOUBLE_EQ(-1.0, cmd.chassis_vel.x);
+}
+
+TEST_F(GameClientTest, KeyASetsChassisLeft)
+{
+  auto input = MakeInput();
+  input.key_a = true;
+  node_->GameDataInputCB(std::make_shared<attracts_msgs::msg::GameDataInput>(input));
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_DOUBLE_EQ(1.0, cmd.chassis_vel.y);
+}
+
+TEST_F(GameClientTest, KeyDSetsChassisRight)
+{
+  auto input = MakeInput();
+  input.key_d = true;
+  node_->GameDataInputCB(std::make_shared<attracts_msgs::msg::GameDataInput>(input));
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_DOUBLE_EQ(-1.0, cmd.chassis_vel.y);
+}
+
+TEST_F(GameClientTest, KeyZSetsChassisRotCcw)
+{
+  auto input = MakeInput();
+  input.key_z = true;
+  node_->GameDataInputCB(std::make_shared<attracts_msgs::msg::GameDataInput>(input));
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_DOUBLE_EQ(2.0, cmd.chassis_vel.z);
+}
+
+TEST_F(GameClientTest, KeyCSetsChassisRotCw)
+{
+  auto input = MakeInput();
+  input.key_c = true;
+  node_->GameDataInputCB(std::make_shared<attracts_msgs::msg::GameDataInput>(input));
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_DOUBLE_EQ(-2.0, cmd.chassis_vel.z);
+}
+
+TEST_F(GameClientTest, MouseDeltaXSetsYaw)
+{
+  auto input = MakeInput();
+  input.mouse_delta_x = 100;  // yaw_pos = 0 + 100/100 = 1.0
+  node_->GameDataInputCB(std::make_shared<attracts_msgs::msg::GameDataInput>(input));
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_DOUBLE_EQ(1.0, cmd.yaw_pos);
+}
+
+TEST_F(GameClientTest, YawWrapsNegative)
+{
+  auto input = MakeInput();
+  input.mouse_delta_x = -1000;  // yaw = -10, fmod → negative → add 2π
+  node_->GameDataInputCB(std::make_shared<attracts_msgs::msg::GameDataInput>(input));
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_GE(cmd.yaw_pos, 0.0);
+}
+
+TEST_F(GameClientTest, PitchClampedLow)
+{
+  auto input = MakeInput();
+  input.mouse_delta_y = -1000;  // pitch = -10 → clamped to -M_PI/12
+  node_->GameDataInputCB(std::make_shared<attracts_msgs::msg::GameDataInput>(input));
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_NEAR(-M_PI / 12, cmd.pitch_pos, 1e-6);
+}
+
+TEST_F(GameClientTest, PitchClampedHigh)
+{
+  auto input = MakeInput();
+  input.mouse_delta_y = 1000;  // pitch = 10 → clamped to M_PI/6
+  node_->GameDataInputCB(std::make_shared<attracts_msgs::msg::GameDataInput>(input));
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_NEAR(M_PI / 6, cmd.pitch_pos, 1e-6);
+}
+
+TEST_F(GameClientTest, MouseRightButtonSetsFire)
+{
+  auto input = MakeInput();
+  input.mouse_right_button = true;
+  node_->GameDataInputCB(std::make_shared<attracts_msgs::msg::GameDataInput>(input));
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_EQ(1, cmd.fire_mode);
+}
+
+TEST_F(GameClientTest, MouseLeftButtonSetsLoad)
+{
+  auto input = MakeInput();
+  input.mouse_left_button = true;
+  node_->GameDataInputCB(std::make_shared<attracts_msgs::msg::GameDataInput>(input));
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_EQ(1, cmd.load_mode);
+}
+
+TEST_F(GameClientTest, KeyRSetsLoad2)
+{
+  auto input = MakeInput();
+  input.key_r = true;
+  node_->GameDataInputCB(std::make_shared<attracts_msgs::msg::GameDataInput>(input));
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_EQ(2, cmd.load_mode);
+}
+
+TEST_F(GameClientTest, KeyShiftSetsChassisModeOn)
+{
+  auto input = MakeInput();
+  input.key_shift = true;
+  node_->GameDataInputCB(std::make_shared<attracts_msgs::msg::GameDataInput>(input));
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_EQ(1, cmd.chassis_mode);
+}
+
+TEST_F(GameClientTest, SpeedModeAlwaysZero)
+{
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_EQ(0, cmd.speed_mode);
+}
+
+TEST_F(GameClientTest, UpdatePositionsRuns)
+{
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_NO_THROW(node_->UpdatePositions(cmd));
+}
+
+TEST_F(GameClientTest, GameDataInputCBSetsMsg)
+{
+  auto input = MakeInput();
+  input.key_w = true;
+  node_->GameDataInputCB(std::make_shared<attracts_msgs::msg::GameDataInput>(input));
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_DOUBLE_EQ(1.0, cmd.chassis_vel.x);
+}

--- a/test/test_gamepad.cpp
+++ b/test/test_gamepad.cpp
@@ -1,0 +1,229 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include "attracts_interface/gamepad_node.hpp"
+
+class GamepadTest : public ::testing::Test
+{
+protected:
+  static void SetUpTestSuite()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestSuite()
+  {
+    rclcpp::shutdown();
+  }
+
+  void SetUp() override
+  {
+    auto options = rclcpp::NodeOptions().parameter_overrides({
+      rclcpp::Parameter("max_omni_vel", 1.0),
+      rclcpp::Parameter("max_omni_rot_vel", 2.0),
+      rclcpp::Parameter("max_yaw_rot_vel", 3.0),
+      rclcpp::Parameter("max_pitch_rot_vel", 3.0),
+      });
+    node_ = std::make_shared<Gamepad>(options);
+  }
+
+  void TearDown() override
+  {
+    node_.reset();
+  }
+
+  // Build a minimal Joy message with 8 axes and 8 buttons (all zero)
+  static sensor_msgs::msg::Joy MakeJoy()
+  {
+    sensor_msgs::msg::Joy joy;
+    joy.axes.resize(8, 0.0f);
+    joy.buttons.resize(8, 0);
+    return joy;
+  }
+
+  std::shared_ptr<Gamepad> node_;
+};
+
+TEST_F(GamepadTest, DpadUpSetsChassisFwd)
+{
+  auto joy = MakeJoy();
+  joy.axes[7] = 1.0f;
+  node_->JoyCB(std::make_shared<sensor_msgs::msg::Joy>(joy));
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_DOUBLE_EQ(1.0, cmd.chassis_vel.x);
+}
+
+TEST_F(GamepadTest, DpadDownSetsChassisBwd)
+{
+  auto joy = MakeJoy();
+  joy.axes[7] = -1.0f;
+  node_->JoyCB(std::make_shared<sensor_msgs::msg::Joy>(joy));
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_DOUBLE_EQ(-1.0, cmd.chassis_vel.x);
+}
+
+TEST_F(GamepadTest, DpadLeftSetsChassisLeft)
+{
+  auto joy = MakeJoy();
+  joy.axes[6] = 1.0f;
+  node_->JoyCB(std::make_shared<sensor_msgs::msg::Joy>(joy));
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_DOUBLE_EQ(1.0, cmd.chassis_vel.y);
+}
+
+TEST_F(GamepadTest, DpadRightSetsChassisRight)
+{
+  auto joy = MakeJoy();
+  joy.axes[6] = -1.0f;
+  node_->JoyCB(std::make_shared<sensor_msgs::msg::Joy>(joy));
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_DOUBLE_EQ(-1.0, cmd.chassis_vel.y);
+}
+
+TEST_F(GamepadTest, Button6SetsRotCcw)
+{
+  auto joy = MakeJoy();
+  joy.buttons[6] = 1;
+  node_->JoyCB(std::make_shared<sensor_msgs::msg::Joy>(joy));
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_DOUBLE_EQ(2.0, cmd.chassis_vel.z);
+}
+
+TEST_F(GamepadTest, Button7SetsRotCw)
+{
+  auto joy = MakeJoy();
+  joy.buttons[7] = 1;
+  node_->JoyCB(std::make_shared<sensor_msgs::msg::Joy>(joy));
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_DOUBLE_EQ(-2.0, cmd.chassis_vel.z);
+}
+
+TEST_F(GamepadTest, Axis3SetsYaw)
+{
+  auto joy = MakeJoy();
+  joy.axes[3] = 10.0f;  // yaw_pos = 0 + 10/10 = 1.0
+  node_->JoyCB(std::make_shared<sensor_msgs::msg::Joy>(joy));
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_DOUBLE_EQ(1.0, cmd.yaw_pos);
+}
+
+TEST_F(GamepadTest, YawWrapsNegative)
+{
+  auto joy = MakeJoy();
+  joy.axes[3] = -1000.0f;  // large negative → wrap
+  node_->JoyCB(std::make_shared<sensor_msgs::msg::Joy>(joy));
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_GE(cmd.yaw_pos, 0.0);
+}
+
+TEST_F(GamepadTest, PitchClampedLow)
+{
+  auto joy = MakeJoy();
+  joy.axes[4] = -1000.0f;  // large negative → clamp to -M_PI/12
+  node_->JoyCB(std::make_shared<sensor_msgs::msg::Joy>(joy));
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_NEAR(-M_PI / 12, cmd.pitch_pos, 1e-6);
+}
+
+TEST_F(GamepadTest, PitchClampedHigh)
+{
+  auto joy = MakeJoy();
+  joy.axes[4] = 1000.0f;  // large positive → clamp to M_PI/6
+  node_->JoyCB(std::make_shared<sensor_msgs::msg::Joy>(joy));
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_NEAR(M_PI / 6, cmd.pitch_pos, 1e-6);
+}
+
+TEST_F(GamepadTest, Button5SetsFire)
+{
+  auto joy = MakeJoy();
+  joy.buttons[5] = 1;
+  node_->JoyCB(std::make_shared<sensor_msgs::msg::Joy>(joy));
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_EQ(1, cmd.fire_mode);
+}
+
+TEST_F(GamepadTest, Button4SetsLoad)
+{
+  auto joy = MakeJoy();
+  joy.buttons[4] = 1;
+  node_->JoyCB(std::make_shared<sensor_msgs::msg::Joy>(joy));
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_EQ(1, cmd.load_mode);
+}
+
+TEST_F(GamepadTest, Button0SetsLoad2)
+{
+  auto joy = MakeJoy();
+  joy.buttons[0] = 1;
+  node_->JoyCB(std::make_shared<sensor_msgs::msg::Joy>(joy));
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_EQ(2, cmd.load_mode);
+}
+
+TEST_F(GamepadTest, Button1SetsChassisMode)
+{
+  auto joy = MakeJoy();
+  joy.buttons[1] = 1;
+  node_->JoyCB(std::make_shared<sensor_msgs::msg::Joy>(joy));
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_EQ(1, cmd.chassis_mode);
+}
+
+TEST_F(GamepadTest, SpeedModeAlwaysZero)
+{
+  auto joy = MakeJoy();
+  node_->JoyCB(std::make_shared<sensor_msgs::msg::Joy>(joy));
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_EQ(0, cmd.speed_mode);
+}
+
+TEST_F(GamepadTest, UpdatePositionsRuns)
+{
+  auto joy = MakeJoy();
+  node_->JoyCB(std::make_shared<sensor_msgs::msg::Joy>(joy));
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_NO_THROW(node_->UpdatePositions(cmd));
+}
+
+TEST_F(GamepadTest, TimerCBWithEmptyJoyNoOp)
+{
+  // joy_msg_ is default (empty axes/buttons) → condition fails → no crash
+  EXPECT_NO_THROW(node_->TimerCB());
+}
+
+TEST_F(GamepadTest, TimerCBWithJoyExecutes)
+{
+  auto joy = MakeJoy();
+  node_->JoyCB(std::make_shared<sensor_msgs::msg::Joy>(joy));
+  EXPECT_NO_THROW(node_->TimerCB());
+}
+
+TEST_F(GamepadTest, JoyCBSetsJoyMsg)
+{
+  auto joy = MakeJoy();
+  joy.axes[7] = 1.0f;
+  node_->JoyCB(std::make_shared<sensor_msgs::msg::Joy>(joy));
+  attracts_msgs::msg::AttractsCommand cmd;
+  node_->UpdateCmdVel(cmd);
+  EXPECT_DOUBLE_EQ(1.0, cmd.chassis_vel.x);
+}


### PR DESCRIPTION
## 変更内容
- インクルードガードをROS2形式（`PACKAGE__SUBDIR__FILE_HPP_`）に変更
- privateセクションを1つに統合
- NodeOptionsコンストラクタ追加（テスタビリティ向上）
- UpdateCmdVel・UpdatePositionsをpublic化
- ソースのスタイル修正（Cキャスト→static_cast・positions初期化・整形）
- ライブラリ/main分割
- launchファイルのflake8修正
- amentリンター設定追加（copyright・cpplint除外）
- gtestユニットテスト追加（36 tests, 0 failures）